### PR TITLE
Improve benchmarks, speed up encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+## Changed
+
+* The encoding functions now use binary search, eliminating a lot of
+  steps when encoding smaller numbers in wider types like `u32` and
+  `u64`.
+
+
 ## [[0.2.0](https://docs.rs/fibonacci_codec/0.2.0/fibonacci_codec/)] - 2021-05-01
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 
 ## Changed
 
-* The encoding functions now use binary search, eliminating a lot of
-  steps when encoding smaller numbers in wider types like `u32` and
-  `u64`.
+* The encoding function now does less unnecessary work, speeding it up
+  by about 10% in local benchmarks.
+* The benchmarks now measure performance for a more even (and larger)
+  distribution of integers.
 
 
 ## [[0.2.0](https://docs.rs/fibonacci_codec/0.2.0/fibonacci_codec/)] - 2021-05-01

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ num = "0.4"
 [dev-dependencies]
 proptest = "1.0.0"
 criterion = "0.3"
+rand = "0.8.0"

--- a/benches/fibonacci_codec.rs
+++ b/benches/fibonacci_codec.rs
@@ -3,8 +3,12 @@ extern crate criterion;
 
 use bit_vec::BitVec;
 use fibonacci_codec::*;
+use rand::{
+    distributions::{Distribution, Uniform},
+    thread_rng,
+};
 
-use criterion::{black_box, Criterion, ParameterizedBenchmark, Throughput};
+use criterion::{black_box, BatchSize, Criterion, ParameterizedBenchmark, Throughput};
 
 #[derive(Debug)]
 enum Width {
@@ -14,39 +18,34 @@ enum Width {
     U64,
 }
 
-impl Width {
-    #[inline]
-    fn sample(&self) -> u64 {
-        match *self {
-            Width::U8 => 0xf0,
-            Width::U16 => 0xfff0,
-            Width::U32 => 0xfffffff0,
-            Width::U64 => 0xfffffffffffffff0,
-        }
-    }
-
-    fn decode(&self, bits: &BitVec) -> usize {
-        match *self {
-            Width::U8 => fib_decode_u8(bits).count(),
-            Width::U16 => fib_decode_u16(bits).count(),
-            Width::U32 => fib_decode_u32(bits).count(),
-            Width::U64 => fib_decode_u64(bits).count(),
-        }
-    }
-}
-
 const ALL: &'static [Width; 4] = &[Width::U8, Width::U16, Width::U32, Width::U64];
-const ELTS: usize = 20;
+const ELTS: usize = 500;
 
 fn encode_multiple_benchmark(c: &mut Criterion) {
+    macro_rules! logic {
+        ($b:expr, $t:ty, $rng:expr) => {{
+            $b.iter_batched(
+                || {
+                    let range = Uniform::new(1 as $t, <$t>::MAX);
+                    range.sample_iter(&mut $rng).take(ELTS).collect::<Vec<$t>>()
+                },
+                |v| black_box(v.fib_encode().expect("should encode right")),
+                BatchSize::LargeInput,
+            )
+        }};
+    }
+
     let id = "encode_multiple";
     let bm = ParameterizedBenchmark::new(
         id,
         |b, ref n| {
-            b.iter(|| {
-                let v = vec![n.sample(); ELTS];
-                v.fib_encode().expect("should be encodable")
-            })
+            let mut thread_rng = thread_rng();
+            match n {
+                Width::U8 => logic!(b, u8, thread_rng),
+                Width::U16 => logic!(b, u16, thread_rng),
+                Width::U32 => logic!(b, u32, thread_rng),
+                Width::U64 => logic!(b, u64, thread_rng),
+            }
         },
         ALL,
     )
@@ -55,13 +54,31 @@ fn encode_multiple_benchmark(c: &mut Criterion) {
 }
 
 fn decode_multiple_benchmark(c: &mut Criterion) {
+    macro_rules! logic {
+        ($b:expr, $t:ty, $dec:expr, $rng:expr) => {{
+            $b.iter_batched(
+                || {
+                    let range = Uniform::new(1 as $t, <$t>::MAX);
+                    let v: Vec<$t> = range.sample_iter(&mut $rng).take(ELTS).collect();
+                    v.fib_encode().expect("should encode right")
+                },
+                |bits| black_box($dec(&bits).count()),
+                BatchSize::LargeInput,
+            )
+        }};
+    }
+
     let id = "decode_multiple";
     let bm = ParameterizedBenchmark::new(
         id,
-        |b, ref d| {
-            let input = vec![d.sample(); ELTS];
-            let bits = input.fib_encode().unwrap();
-            b.iter(move || assert_eq!(ELTS, d.decode(&bits)));
+        |b, ref n| {
+            let mut thread_rng = thread_rng();
+            match n {
+                Width::U8 => logic!(b, u8, fib_decode_u8, thread_rng),
+                Width::U16 => logic!(b, u16, fib_decode_u16, thread_rng),
+                Width::U32 => logic!(b, u32, fib_decode_u32, thread_rng),
+                Width::U64 => logic!(b, u64, fib_decode_u64, thread_rng),
+            }
         },
         ALL,
     )
@@ -70,20 +87,54 @@ fn decode_multiple_benchmark(c: &mut Criterion) {
 }
 
 fn encode_1_benchmark(c: &mut Criterion) {
+    macro_rules! logic {
+        ($b:expr, $t:ty, $rng:expr) => {{
+            let range = Uniform::new(1 as $t, <$t>::MAX);
+            $b.iter_batched(
+                || range.sample(&mut $rng),
+                |n| black_box(n.fib_encode().expect("should encode")),
+                BatchSize::SmallInput,
+            )
+        }};
+    }
+
     c.bench_function_over_inputs(
         "encode_1",
-        |b, ref n| b.iter(|| n.sample().fib_encode().expect("should be encodable")),
+        |b, ref n| {
+            let mut thread_rng = thread_rng();
+            match n {
+                Width::U8 => logic!(b, u8, thread_rng),
+                Width::U16 => logic!(b, u16, thread_rng),
+                Width::U32 => logic!(b, u32, thread_rng),
+                Width::U64 => logic!(b, u64, thread_rng),
+            }
+        },
         ALL,
     );
 }
 
 fn decode_1_benchmark(c: &mut Criterion) {
+    macro_rules! logic {
+        ($b:expr, $t:ty, $dec:expr, $rng:expr) => {{
+            let range = Uniform::new(1 as $t, <$t>::MAX);
+            $b.iter_batched(
+                || range.sample(&mut $rng).fib_encode().expect("should encode"),
+                |bits| black_box($dec(bits).count()),
+                BatchSize::SmallInput,
+            )
+        }};
+    }
+
     c.bench_function_over_inputs(
         "decode_1",
-        |b, ref d| {
-            let input = d.sample();
-            let bits = input.fib_encode().unwrap();
-            b.iter(move || black_box(d.decode(&bits)));
+        |b, ref n| {
+            let mut thread_rng = thread_rng();
+            match n {
+                Width::U8 => logic!(b, u8, fib_decode_u8, thread_rng),
+                Width::U16 => logic!(b, u16, fib_decode_u16, thread_rng),
+                Width::U32 => logic!(b, u32, fib_decode_u32, thread_rng),
+                Width::U64 => logic!(b, u64, fib_decode_u64, thread_rng),
+            }
         },
         ALL,
     );

--- a/bors.toml
+++ b/bors.toml
@@ -7,5 +7,5 @@ status = [
   "all_tests",
   "rustfmt",
 ]
-timeout_sec = 300
+timeout_sec = 600
 delete_merged_branches = true

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -143,9 +143,7 @@ where
     result.set(i, true);
     for elt in table.split_at(split_pos + 1).0.iter().rev() {
         i -= 1;
-        let bit = if elt > &current {
-            false
-        } else {
+        if elt <= &current {
             let next = match current.checked_sub(elt) {
                 Some(next) => next,
                 None => {
@@ -158,9 +156,8 @@ where
                 }
             };
             current = next;
-            true
+            result.set(i, true);
         };
-        result.set(i, bit);
     }
     Ok(())
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -130,13 +130,14 @@ pub(crate) fn bits_from_table<T>(
     result: &mut BitVec,
 ) -> Result<(), EncodeError<T>>
 where
-    T: CheckedSub + PartialOrd + Debug + Copy + Send + Sync + 'static,
+    T: CheckedSub + PartialOrd + Ord + Debug + Copy + Send + Sync + 'static,
 {
     let mut current = n;
-    let split_pos = table
-        .iter()
-        .rposition(|elt| *elt <= n)
-        .ok_or(EncodeError::ValueTooSmall::<T>(n))?;
+    let split_pos = match table.binary_search(&n) {
+        Ok(n) => n,
+        Err(n) if n > 0 => n - 1,
+        Err(_) => return Err(EncodeError::ValueTooSmall::<T>(n)),
+    };
 
     let mut i = result.len() + split_pos + 1;
     result.grow(split_pos + 2, false);

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -133,35 +133,34 @@ where
     T: CheckedSub + PartialOrd + Ord + Debug + Copy + Send + Sync + 'static,
 {
     let mut current = n;
-    let split_pos = match table.binary_search(&n) {
+    let mut i_entry = match table.binary_search(&current) {
         Ok(n) => n,
         Err(n) if n > 0 => n - 1,
         Err(_) => return Err(EncodeError::ValueTooSmall::<T>(n)),
     };
-
-    let mut i = result.len() + split_pos + 1;
-    result.grow(split_pos + 2, false);
-    result.set(i, true);
-    for elt in table[0..=split_pos].iter().rev() {
-        i -= 1;
-        let bit = if elt > &current {
-            false
-        } else {
-            let next = match current.checked_sub(elt) {
-                Some(next) => next,
-                None => {
-                    // We encountered an underflow. This is a bug, and
-                    // I have no idea how it could even occur in real
-                    // life. However, let's clean up and return a
-                    // reasonable error:
-                    result.truncate(split_pos + 2);
-                    return Err(EncodeError::Underflow(n));
-                }
-            };
-            current = next;
-            true
+    let mut i = result.len() + i_entry;
+    result.grow(i_entry + 2, false);
+    result.set(i + 1, true);
+    loop {
+        let elt = table[i_entry];
+        result.set(i, true);
+        current = match current.checked_sub(&elt) {
+            Some(next) => next,
+            None => {
+                // We encountered an underflow. This is a bug, and
+                // I have no idea how it could even occur in real
+                // life. However, let's clean up and return a
+                // reasonable error:
+                result.truncate(i + 2);
+                return Err(EncodeError::Underflow(n));
+            }
         };
-        result.set(i, bit);
+        let new_i_entry = match table.binary_search(&current) {
+            Ok(n) => n,
+            Err(n) if n > 0 => n - 1,
+            Err(_) => return Ok(()),
+        };
+        i -= i_entry - new_i_entry;
+        i_entry = new_i_entry;
     }
-    Ok(())
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -142,7 +142,7 @@ where
     let mut i = result.len() + split_pos + 1;
     result.grow(split_pos + 2, false);
     result.set(i, true);
-    for elt in table.split_at(split_pos + 1).0.iter().rev() {
+    for elt in table[0..=split_pos].iter().rev() {
         i -= 1;
         let bit = if elt > &current {
             false

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -8,6 +8,7 @@ fn to_bits(slice: BitVec) -> Vec<u8> {
 #[test]
 fn test_factor_wikipedia() {
     // Some of the examples on https://en.wikipedia.org/wiki/Fibonacci_coding:
+    assert_eq!(vec![1, 1], to_bits((1 as u8).fib_encode().unwrap()));
     assert_eq!(vec![0, 1, 1], to_bits((2 as u8).fib_encode().unwrap()));
     assert_eq!(vec![1, 0, 1, 1], to_bits((4 as u8).fib_encode().unwrap()));
     assert_eq!(vec![0, 0, 1, 1], to_bits((3 as u8).fib_encode().unwrap()));


### PR DESCRIPTION
The most interesting change here is in benchmarks: Now, they use a random distribution of generated numbers to encode/decode, which should result in a more even measurement of all the performance behaviors, as fib-encoding is really sensitive to the number being encoded.

Also, improve the performance of `encode` by only setting a bit if we're setting it to 1: They're all already 0, and that saves about 20% of encoding time, apparently.